### PR TITLE
Updates from testing (#4)

### DIFF
--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -62,8 +62,9 @@ jobs:
 
           # Setting up main qiita conda environment
           conda config --add channels conda-forge
-          conda create -q --yes -n qiita python=3.6 pip libgfortran numpy nginx cython redis
+          conda create -q --yes -n qiita python=3.6 pip==9.0.3 libgfortran numpy nginx cython redis
           conda activate qiita
+          pip install --upgrade pip
           pip install 'setuptools<=58.0.1'
           pip install sphinx sphinx-bootstrap-theme nose-timer codecov Click
 
@@ -77,7 +78,7 @@ jobs:
       - name: Install Qiita plugins
         shell: bash -l {0}
         run: |
-          conda create -q --yes -n klp python=3.6
+          conda create -q --yes -n klp python=3.6 pip==9.0.3
           conda activate klp
 
           export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/server.crt
@@ -87,9 +88,10 @@ jobs:
           pip --quiet install https://github.com/qiita-spots/qtp-job-output-folder/archive/refs/heads/main.zip
           pip --quiet install .
           pip --quiet install coveralls
+          export QP_KLP_CONFIG_FP=`pwd`/configuration.json
 
           configure_qtp_job_output_folder --env-script "source /home/runner/.profile; conda activate klp" --server-cert $QIITA_SERVER_CERT
-          configure_klp --env-script "source /home/runner/.profile; conda activate klp" --server-cert $QIITA_SERVER_CERT
+          configure_klp --env-script "source /home/runner/.profile; export QP_KLP_CONFIG_FP=$QP_KLP_CONFIG_FP; conda activate klp" --server-cert $QIITA_SERVER_CERT
 
           echo "Available Qiita plugins"
           ls ~/.qiita_plugins/
@@ -132,7 +134,7 @@ jobs:
           conda activate klp
           export QIITA_SERVER_CERT=`pwd`/qiita-dev/qiita_core/support_files/server.crt
           export QIITA_CONFIG_FP=`pwd`/qiita-dev/qiita_core/support_files/config_test_local.cfg
-
+          export QP_KLP_CONFIG_FP=`pwd`/configuration.json
           export PYTHONWARNINGS="ignore:Certificate for localhost has no \`subjectAltName\`"
 
           nosetests --with-doctest --with-coverage -v --cover-package=qp_klp

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Plugin configuration file
+configuration.json

--- a/qp_klp/__init__.py
+++ b/qp_klp/__init__.py
@@ -21,8 +21,7 @@ plugin = QiitaPluginAdmin('qp-klp', __version__, 'Knight Lab Processing')
 
 req_params = {
     'run_identifier': ('string', ['']),
-    'sample_sheet': ('prep_template', ['']),
-}
+    'sample_sheet': ('prep_template', [''])}
 opt_params = dict()
 outputs = {'output': 'job-output-folder'}
 dflt_param_set = dict()

--- a/qp_klp/klp.py
+++ b/qp_klp/klp.py
@@ -5,12 +5,24 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # -----------------------------------------------------------------------------
-
-from os.path import exists, isdir, join
-from glob import glob
 from functools import partial
-
 from qiita_client import ArtifactInfo
+from sequence_processing_pipeline.Pipeline import Pipeline
+from os import makedirs
+from os.path import join
+from sequence_processing_pipeline.ConvertJob import ConvertJob
+from sequence_processing_pipeline.QCJob import QCJob
+from sequence_processing_pipeline.FastQCJob import FastQCJob
+from sequence_processing_pipeline.GenPrepFileJob import GenPrepFileJob
+from sequence_processing_pipeline.SequenceDirectory import SequenceDirectory
+from sequence_processing_pipeline.PipelineError import PipelineError
+from metapool import KLSampleSheet, validate_and_scrub_sample_sheet
+from subprocess import Popen, PIPE
+from os import environ, walk
+from inspect import stack
+
+
+CONFIG_FP = environ["QP_KLP_CONFIG_FP"]
 
 
 def sequence_processing_pipeline(qclient, job_id, parameters, out_dir):
@@ -32,32 +44,225 @@ def sequence_processing_pipeline(qclient, job_id, parameters, out_dir):
     bool, list, str
         The results of the job
     """
-    qclient.update_job_step(job_id, "Step 1 of 3: Collecting information")
     run_identifier = parameters.pop('run_identifier')
     sample_sheet = parameters.pop('sample_sheet')
+    job_pool_size = 30
+
+    # checking if this is running as part of the unittest
+    # https://stackoverflow.com/a/25025987
+    skip_exec = True if [x for x in stack() if
+                         'unittest' in x.filename] else False
 
     success = True
     ainfo = None
     msg = None
-    if exists(run_identifier) and isdir(run_identifier):
-        if {'body', 'content_type', 'filename'} == set(sample_sheet):
-            outpath = partial(join, out_dir)
 
-            with open(outpath('listing.txt'), 'w') as f:
-                f.write('\n'.join(glob(join(run_identifier, '*'))))
+    qclient.update_job_step(job_id, "Step 1 of 6: Setting up pipeline")
 
-            with open(outpath(sample_sheet['filename']), 'w') as f:
-                f.write(sample_sheet['body'])
+    if {'body', 'content_type', 'filename'} == set(sample_sheet):
+        outpath = partial(join, out_dir)
+        final_results_path = outpath('final_results')
+        makedirs(final_results_path, exist_ok=True)
 
-            ainfo = [
-                ArtifactInfo('output', 'job-output-folder',
-                             [(f'{out_dir}/', 'directory')])
-            ]
+        # the user is uploading a sample-sheet to us, but we need the
+        # sample-sheet as a file to pass to the Pipeline().
+        sample_sheet_path = outpath(sample_sheet['filename'])
+        with open(sample_sheet_path, 'w') as f:
+            f.write(sample_sheet['body'])
+
+        # validate the sample-sheet using metapool package.
+        sheet = KLSampleSheet(sample_sheet_path)
+        val_sheet = validate_and_scrub_sample_sheet(sheet)
+        if not val_sheet:
+            qclient.update_job_step(job_id,
+                                    "Sample sheet failed validation.")
+            raise ValueError("Sample sheet failed validiation")
         else:
-            success = False
-            msg = "Doesn't look like a valid uploaded file; please review."
+            # get project names and their associated qiita ids
+            bioinformatics = val_sheet.Bioinformatics
+            lst = bioinformatics.to_dict('records')
+
+        # find the uploads directory all trimmed files will need to be
+        # moved to.
+        results = qclient.get("/qiita_db/artifacts/types/")
+
+        # trimmed files are stored by qiita_id. Find the qiita_id
+        # associated with each project and ensure a subdirectory exists
+        # for when it comes time to move the trimmed files.
+        special_map = []
+        for result in lst:
+            project_name = result['Sample_Project']
+            qiita_id = result['QiitaID']
+            upload_path = join(results['uploads'], qiita_id)
+            makedirs(upload_path, exist_ok=True)
+            special_map.append((project_name, upload_path))
+
+        try:
+            pipeline = Pipeline(CONFIG_FP, run_identifier, out_dir, job_id)
+        except PipelineError as e:
+            # Pipeline is the object that finds the input fp, based on
+            # a search directory set in configuration.json and a run_id.
+            if str(e).endswith("could not be found"):
+                msg = f"A path for {run_identifier} could not be found."
+                return False, None, msg
+            else:
+                raise e
+
+        makedirs(join(pipeline.run_dir, run_identifier), exist_ok=True)
+
+        sdo = SequenceDirectory(pipeline.run_dir, sample_sheet_path)
+
+        qclient.update_job_step(job_id,
+                                "Step 2 of 6: Converting BCL to fastq")
+
+        config = pipeline.configuration['bcl-convert']
+        convert_job = ConvertJob(pipeline.run_dir,
+                                 pipeline.output_path,
+                                 sdo.sample_sheet_path,
+                                 config['queue'],
+                                 config['nodes'],
+                                 config['nprocs'],
+                                 config['wallclock_time_in_hours'],
+                                 config['per_process_memory_limit'],
+                                 config['executable_path'],
+                                 config['modules_to_load'],
+                                 job_id)
+
+        # if skip_execution is True, then each Pipeline object will be
+        # initialized, their assertions tested, and an ainfo will be
+        # returned to the caller. However the Jobs will not actually
+        # be executed. This is useful for testing.
+        if not skip_exec:
+            convert_job.run()
+
+        qclient.update_job_step(job_id,
+                                "Step 3 of 6: Adaptor & Host [optional] "
+                                "trimming")
+
+        raw_fastq_files_path = join(pipeline.output_path, 'ConvertJob')
+
+        config = pipeline.configuration['qc']
+        qc_job = QCJob(raw_fastq_files_path,
+                       pipeline.output_path,
+                       sdo.sample_sheet_path,
+                       config['mmi_db'],
+                       config['queue'],
+                       config['nodes'],
+                       config['nprocs'],
+                       config['wallclock_time_in_hours'],
+                       config['job_total_memory_limit'],
+                       config['fastp_executable_path'],
+                       config['minimap2_executable_path'],
+                       config['samtools_executable_path'],
+                       config['modules_to_load'],
+                       job_id,
+                       job_pool_size)
+
+        if not skip_exec:
+            qc_job.run()
+
+        qclient.update_job_step(job_id, "Step 4 of 6: Generating FastQC & "
+                                        "MultiQC reports")
+
+        config = pipeline.configuration['fastqc']
+
+        raw_fastq_files_path = join(pipeline.output_path, 'ConvertJob')
+        processed_fastq_files_path = join(pipeline.output_path, 'QCJob')
+
+        fastqc_job = FastQCJob(pipeline.run_dir,
+                               pipeline.output_path,
+                               raw_fastq_files_path,
+                               processed_fastq_files_path,
+                               config['nprocs'],
+                               config['nthreads'],
+                               config['fastqc_executable_path'],
+                               config['modules_to_load'],
+                               job_id,
+                               config['queue'],
+                               config['nodes'],
+                               config['wallclock_time_in_hours'],
+                               config['job_total_memory_limit'],
+                               job_pool_size,
+                               config['multiqc_config_file_path'])
+
+        if not skip_exec:
+            fastqc_job.run()
+
+        project_list = fastqc_job.project_names
+
+        qclient.update_job_step(job_id, "Step 5 of 6: Generating Prep "
+                                        "Information Files")
+
+        config = pipeline.configuration['seqpro']
+        gpf_job = GenPrepFileJob(
+            pipeline.run_dir,
+            raw_fastq_files_path,
+            processed_fastq_files_path,
+            pipeline.output_path,
+            sdo.sample_sheet_path,
+            config['seqpro_path'],
+            project_list,
+            config['modules_to_load'],
+            job_id)
+
+        if not skip_exec:
+            gpf_job.run()
+
+        qclient.update_job_step(job_id, "Step 6 of 6: Copying results to "
+                                        "archive")
+
+        cmds = [f'cd {out_dir}; tar zcvf logs-ConvertJob.tgz ConvertJob/logs',
+                f'cd {out_dir}; tar zcvf reports-ConvertJob.tgz '
+                'ConvertJob/Reports ConvertJob/Logs',
+                f'cd {out_dir}; tar zcvf logs-QCJob.tgz QCJob/logs',
+                f'cd {out_dir}; tar zcvf logs-FastQCJob.tgz '
+                'FastQCJob/logs',
+                f'cd {out_dir}; tar zcvf reports-FastQCJob.tgz '
+                'FastQCJob/fastqc',
+                f'cd {out_dir}; tar zcvf logs-GenPrepFileJob.tgz '
+                'GenPrepFileJob/logs',
+                f'cd {out_dir}; tar zcvf prep-files.tgz '
+                'GenPrepFileJob/PrepFiles']
+
+        csv_fps = []
+        for root, dirs, files in walk(join(gpf_job.output_path, 'PrepFiles')):
+            for csv_file in files:
+                csv_fps.append(join(root, csv_file))
+
+        for project, upload_dir in special_map:
+            cmds.append(f'cd {out_dir}; tar zcvf reports-QCJob.tgz '
+                        'QCJob/{project}/fastp_reports_dir')
+            cmds.append(f'cd {out_dir}; mv '
+                        'QCJob/{project}/filtered_sequences/* '
+                        '{upload_dir}')
+            for csv_file in csv_fps:
+                if project in csv_file:
+                    cmds.append(f'cd {out_dir}; mv {csv_file} {upload_dir}')
+                    break
+
+        cmds.append(f'cd {out_dir}; mv *.tgz final_results')
+        cmds.append(f'cd {out_dir}; mv FastQCJob/multiqc final_results')
+
+        if skip_exec:
+            cmds = []
+
+        for cmd in cmds:
+            p = Popen(cmd, universal_newlines=True, shell=True,
+                      stdout=PIPE, stderr=PIPE)
+            std_out, std_err = p.communicate()
+            return_code = p.returncode
+            if return_code != 0:
+                raise PipelineError(f"'{cmd}' returned {return_code}")
+
+        ainfo = [
+            ArtifactInfo('output', 'job-output-folder',
+                         [(f'{final_results_path}/', 'directory')])
+        ]
     else:
         success = False
-        msg = "The path doesn't exist or is not a folder"
+        msg = "This doesn't appear to be a valid sample sheet; please review."
+
+    qclient.update_job_step(job_id, "Main Pipeline Finished, processing "
+                                    "results")
 
     return success, ainfo, msg

--- a/qp_klp/tests/test_klp.py
+++ b/qp_klp/tests/test_klp.py
@@ -5,31 +5,219 @@
 #
 # The full license is in the file LICENSE, distributed with this software.
 # -----------------------------------------------------------------------------
-
 from unittest import main
-from os import remove
+from os import remove, makedirs
 from shutil import rmtree
 from json import dumps
 from tempfile import mkdtemp
-from os.path import exists, isdir, realpath, dirname
-
+from os.path import exists, isdir, join, realpath, dirname
 from qiita_client.testing import PluginTestCase
 from qiita_client import ArtifactInfo
-
 from qp_klp import __version__, plugin
-
 from qp_klp.klp import sequence_processing_pipeline
+from time import sleep
+from os import environ
 
 
 class KLPTests(PluginTestCase):
+    def _make_temp_dir(self):
+        new_dir = mkdtemp()
+        self._clean_up_files.append(new_dir)
+        return new_dir
+
     def setUp(self):
         # this will allow us to see the full errors
         self.maxDiff = None
 
-        plugin("https://localhost:8383", 'register', 'ignored')
+        plugin('https://localhost:8383', 'register', 'ignored')
+        sleep(2)
+
         self._clean_up_files = []
 
         self.basedir = dirname(realpath(__file__))
+
+        self.multiqc_config_filepath = join(self._make_temp_dir(),
+                                            'multiqc-config.yaml')
+        self.multiqc_config_data = [
+            "title: 'Sequence processing summaries'\n",
+            "output_fn_name: 'index.html'\n",
+            "show_analysis_paths: False\n",
+            "show_analysis_time: False\n",
+            "run_modules:\n",
+            "    - bclconvert\n",
+            "    - fastqc\n",
+            "    - fastp\n",
+            "sample_names_ignore:\n",
+            "    - 'blank*'\n",
+            "    - 'BLANK*'\n",
+            "no_version_check: False\n",
+            "plots_force_interactive: True\n",
+            "num_datasets_plot_limit: 1\n",
+            "max_table_rows: 10000\n",
+            "table_columns_visible:\n",
+            "    'Sequence Quality (bclconvert raw)':\n",
+            "        percent_fails: False\n",
+            "        percent_duplicates: False\n",
+            "        percent_gc: False\n",
+            "        avg_sequence_length: True\n",
+            "        total_sequences: True\n",
+            "    'Trimming':\n",
+            "        input_format: False\n",
+            "        avg_sequence_length: False\n",
+            "        total_record_count: False\n",
+            "        mean_sequence_length: False\n",
+            "        fraction_bp_trimmed: False\n",
+            "        fraction_records_with_adapters: False\n",
+            "    'Sequence Quality (trimmed)':\n",
+            "        percent_fails: False\n",
+            "        percent_duplicates: False\n",
+            "        percent_gc: False\n",
+            "        avg_sequence_length: True\n",
+            "        total_sequences: True\n",
+            "    'Human Filtering':\n",
+            "        overall_alignment_rate: True\n",
+            "    'Sequence Quality (filtered)':\n",
+            "        percent_fails: False\n",
+            "        percent_duplicates: False\n",
+            "        percent_gc: False\n",
+            "        avg_sequence_length: True\n",
+            "        total_sequences: True\n",
+            "module_order:\n",
+            "    - bclconvert:\n",
+            "         name: 'Base Calling'\n",
+            "         info: 'Conversion from BCL files to FASTQ files.'\n",
+            "    - fastqc:\n",
+            "        name: 'Sequence Quality (raw)'\n",
+            "        info: 'Sequence quality and summary statistics for raw s",
+            "equences.'\n",
+            "        path_filters:\n",
+            "            - '*fastqc.zip'\n",
+            "            - '*.csv'\n",
+            "    - fastp:\n",
+            "        name: 'Sequence Quality (adapter trimmed)'\n",
+            "        info: 'Summary statistics from adapter trimming and qual",
+            "ity control with fastp.'\n",
+            "        fn: '*.json'\n",
+            "    - fastqc:\n",
+            "        name: 'Sequence Quality (trimmed)'\n",
+            "        info: 'Sequence quality and summary statistics after qua",
+            "lity-control and adapter trimming.'\n",
+            "        path_filters:\n",
+            "          - '*trimmed_fastqc.zip'\n",
+            "          - '*fastp_fastqc.zip'\n"
+        ]
+
+        self.sample_csv_data = [
+            "[Header],,,,,,,,,,\n",
+            "IEMFileVersion,4,,,,,,,,,\n",
+            "Investigator Name,Knight,,,,,,,,,\n",
+            "Experiment Name,RKL0042,,,,,,,,,\n",
+            "Date,2/26/20,,,,,,,,,\n",
+            "Workflow,GenerateFASTQ,,,,,,,,,\n",
+            "Application,FASTQ Only,,,,,,,,,\n",
+            "Assay,Metagenomics,,,,,,,,,\n",
+            "Description,,,,,,,,,,\n",
+            "Chemistry,Default,,,,,,,,,\n",
+            ",,,,,,,,,,\n",
+            "[Reads],,,,,,,,,,\n",
+            "150,,,,,,,,,,\n",
+            "150,,,,,,,,,,\n",
+            ",,,,,,,,,,\n",
+            "[Settings],,,,,,,,,,\n",
+            "ReverseComplement,0,,,,,,,,,\n",
+            ",,,,,,,,,,\n",
+            "[Data],,,,,,,,,,\n",
+            "Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,"
+            "index,I5_Index_ID,index2,Sample_Project,Well_description\n",
+            "1,CDPH-SAL_Salmonella_Typhi_MDL-143,CDPH-SAL_Salmonella_Typhi_MD"
+            "L-143,Feist_11661_P40,A1,iTru7_107_07,CCGACTAT,iTru5_01_A,ACCGAC"
+            "AA,Feist_11661,CDPH-SAL_Salmonella Typhi_MDL-143\n",
+            "1,CDPH-SAL_Salmonella_Typhi_MDL-144,CDPH-SAL_Salmonella_Typhi_MD"
+            "L-144,Feist_11661_P40,C1,iTru7_107_08,CCGACTAT,iTru5_02_A,CTTCGC"
+            "AA,Feist_11661,CDPH-SAL_Salmonella Typhi_MDL-144\n",
+            ",,,,,,,,,,\n",
+            "[Bioinformatics],,,,,,,,,,\n",
+            "Sample_Project,QiitaID,BarcodesAreRC,ForwardAdapter,ReverseAdapt"
+            "er,HumanFiltering,library_construction_protocol,experiment_desig"
+            "n_description,,,\n",
+            "Feist_11661,11661,FALSE,AACC,GGTT,FALSE,Knight Lab Kapa HP,Eqiip"
+            "eriment,,,\n",
+            ",,,,,,,,,,\n",
+            "[Contact],,,,,,,,,,\n",
+            "Email,Sample_Project,,,,,,,,,\n",
+            "test@lol.com,Feist_11661,,,,,,,,,\n",
+            ",,,,,,,,,,\n",
+        ]
+
+        self.out_dir = self._make_temp_dir()
+        self.search_dir = self._make_temp_dir()
+
+        spp_config = {
+              "configuration": {
+                "pipeline": {
+                  "younger_than": 90,
+                  "older_than": 24,
+                  "archive_path": '/not/out_dir',
+                  "search_paths": [self.search_dir]
+                },
+                "bcl2fastq": {
+                  "nodes": 1,
+                  "nprocs": 16,
+                  "queue": "qiita",
+                  "wallclock_time_in_hours": 36,
+                  "modules_to_load": ["bcl2fastq_2.20.0.422"],
+                  "executable_path": "bcl2fastq",
+                  "per_process_memory_limit": "10gb"
+                },
+                "bcl-convert": {
+                  "nodes": 1,
+                  "nprocs": 16,
+                  "queue": "qiita",
+                  "wallclock_time_in_hours": 36,
+                  "modules_to_load": ["bclconvert_3.7.5"],
+                  "executable_path": "bcl-convert",
+                  "per_process_memory_limit": "10gb"
+                },
+                "qc": {
+                  "nodes": 1,
+                  "nprocs": 16,
+                  "queue": "qiita",
+                  "wallclock_time_in_hours": 1,
+                  "mmi_db": "/databases/minimap2/human-phix-db.mmi",
+                  "modules_to_load": ["fastp_0.20.1", "samtools_1.12",
+                                      "minimap2_2.18"],
+                  "fastp_executable_path": "fastp",
+                  "minimap2_executable_path": "minimap2",
+                  "samtools_executable_path": "samtools",
+                  "job_total_memory_limit": "20gb",
+                  "job_pool_size": 30
+                },
+                "seqpro": {
+                  "seqpro_path": "seqpro",
+                  "modules_to_load": []
+                },
+                "fastqc": {
+                  "nodes": 1,
+                  "nprocs": 16,
+                  "queue": "qiita",
+                  "nthreads": 16,
+                  "wallclock_time_in_hours": 1,
+                  "modules_to_load": ["fastqc_0.11.5"],
+                  "fastqc_executable_path": "fastqc",
+                  "multiqc_executable_path": "multiqc",
+                  "multiqc_config_file_path": self.multiqc_config_filepath,
+                  "job_total_memory_limit": "20gb",
+                  "job_pool_size": 30
+                }
+              }
+            }
+
+        # create the file and write the configuration out to disk
+        # for use by sequence_processing_pipeline().
+        config_filepath = environ['QP_KLP_CONFIG_FP']
+
+        with open(config_filepath, 'w') as f:
+            f.write(dumps(spp_config, indent=2))
 
     def tearDown(self):
         for fp in self._clean_up_files:
@@ -41,57 +229,109 @@ class KLPTests(PluginTestCase):
 
     def test_sequence_processing_pipeline(self):
         # not a valid run_identifier folder and sample_sheet
-        params = {
-            'run_identifier': '/this/path/doesnt/exist',
-            'sample_sheet': 'NA'}
+        params = {"run_identifier": "NOT_A_RUN_IDENTIFIER",
+                  "sample_sheet": "NA"}
 
         data = {
-            'user': 'demo@microbio.me',
-            'command': dumps(['qp-klp', __version__,
-                              'Sequence Processing Pipeline']),
-            'status': 'running',
-            'parameters': dumps(params)}
-        jid = self.qclient.post('/apitest/processing_job/', data=data)['job']
-        out_dir = mkdtemp()
-        self._clean_up_files.append(out_dir)
+            "user": "demo@microbio.me",
+            "command": dumps(["qp-klp", __version__,
+                              "Sequence Processing Pipeline"]),
+            "status": "running",
+            "parameters": dumps(params),
+        }
+
+        job_id = self.qclient.post("/apitest/processing_job/",
+                                   data=data)["job"]
 
         success, ainfo, msg = sequence_processing_pipeline(
-            self.qclient, jid, params, out_dir)
+            self.qclient, job_id, params, self.out_dir
+        )
         self.assertFalse(success)
-        self.assertEqual(msg, "The path doesn't exist or is not a folder")
+        self.assertEqual(msg, "This doesn't appear to be a valid sample sheet"
+                              "; please review.")
+
+        test_dir = join(self.search_dir, "200318_A00953_0082_AH5TWYDSXY")
+        makedirs(test_dir)
+
+        # create the sentinel files ConvertJob will check for.
+        with open(join(test_dir, 'RTAComplete.txt'), 'w') as f:
+            f.write("Hello World\n")
+
+        with open(join(test_dir, 'RunInfo.xml'), 'w') as f:
+            f.write("Hello World\n")
+
+        # create the project directory QCJob will expect to find fastq files
+        # in.
+        fastq_dir = join(test_dir, 'Data', 'Fastq', 'Feist_11661')
+        makedirs(fastq_dir)
+        file_list = ["CDPH-SAL_Salmonella_Typhi_MDL-143_R1_.fastq.gz",
+                     "CDPH-SAL_Salmonella_Typhi_MDL-143_R2_.fastq.gz",
+                     "CDPH-SAL_Salmonella_Typhi_MDL-144_R1_.fastq.gz",
+                     "CDPH-SAL_Salmonella_Typhi_MDL-144_R2_.fastq.gz"]
+
+        for fastq_file in file_list:
+            with open(join(fastq_dir, fastq_file), 'w') as f:
+                f.write("Hello World\n")
+
+        # write multi-qc config file to a known location
+        with open(self.multiqc_config_filepath, 'w') as f:
+            for line in self.multiqc_config_data:
+                f.write(f"{line}\n")
+
+        # create the Reports directory in the location GenPrepFileJob
+        # expects.
+        reports_dir = join(self.out_dir, 'ConvertJob', 'Reports')
+        makedirs(reports_dir, exist_ok=True)
+
+        # create QCJobs output directory for use by GenPrepFileJob
+        qcj_output_fp = join(self.out_dir, 'QCJob', 'Feist_11661')
+        makedirs(join(qcj_output_fp, 'filtered_sequences'))
+        makedirs(join(qcj_output_fp, 'fastp_reports_dir', 'json'))
 
         # valid run_identifier folder but not sample_sheet
-        # NOTE: we are no creating a new job for this test, which is fine
-        params = {
-            'run_identifier': out_dir,
-            'sample_sheet': 'NA'}
+        # NOTE: we are not creating a new job for this test, which is fine
+        params = {"run_identifier": "200318_A00953_0082_AH5TWYDSXY",
+                  "sample_sheet": "NA"}
 
         success, ainfo, msg = sequence_processing_pipeline(
-            self.qclient, jid, params, out_dir)
+            self.qclient, job_id, params, self.out_dir
+        )
         self.assertFalse(success)
-        self.assertEqual(
-            msg, "Doesn't look like a valid uploaded file; please review.")
+
+        self.assertEqual(msg, "This doesn't appear to be a valid sample sheet"
+                              "; please review.")
 
         # test success
         # both valid run_identifier and sample_sheet
         # NOTE: we are no creating a new job for this test, which is fine
+
         params = {
-            'run_identifier': out_dir,
-            'sample_sheet': {
-                'body': 'sample_name\trun_prefix\n1.SKB1.640202\tSKB1.640202',
-                'content_type': 'text/plain',
-                'filename': 'prep_16S.txt'}}
+            "run_identifier": "200318_A00953_0082_AH5TWYDSXY",
+            "sample_sheet": {
+                "body": ''.join(self.sample_csv_data),
+                "content_type": "text/plain",
+                "filename": "prep_16S.txt",
+            }
+        }
 
         success, ainfo, msg = sequence_processing_pipeline(
-            self.qclient, jid, params, out_dir)
+            self.qclient, job_id, params, self.out_dir
+        )
+
+        if msg:
+            # if success is True, msg should be None.
+            print("Message returned: %s" % msg)
+
         self.assertTrue(success)
-        exp = [
-            ArtifactInfo(
-                'output', 'job-output-folder', [(f'{out_dir}/', 'directory')])
-        ]
+
+        exp = [ArtifactInfo("output",
+                            "job-output-folder",
+                            [(f"{self.out_dir}/final_results/", "directory")]
+                            )
+               ]
 
         self.assertEqual(ainfo, exp)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,8 @@ setup(name='qp-klp',
                         'qiita-files @ https://github.com/'
                         'qiita-spots/qiita-files/archive/master.zip',
                         'qiita_client @ https://github.com/'
-                        'qiita-spots/qiita_client/archive/master.zip'],
+                        'qiita-spots/qiita_client/archive/master.zip',
+                        'sequence-processing-pipeline @ https://github.com/'
+                        'biocore/mg-scripts/archive/master.zip'],
       dependency_links=[],
       classifiers=classifiers)


### PR DESCRIPTION
* Updates from testing

The following updates were made to klp.py during testing by Antonio and Charlie.

* Update qiita-plugin-ci.yml

* Added back sample-sheet validation

Added back sample-sheet validation, as it's also used to get the list of project names used for creating directories downstream.

* Specify certifi version

Test fixing certifi version at the specific version needed or higher, before installing other packages.

* certifi version should be specified in conda install line

* Downgrading initial pip to 9.0.3

Empirically, downgrading pip to 9.0.3 automatically allows for a later version of cerifi (> 2017) to be installed.
Presumably this is due to a change in later pip versions.

* Added pip update

* Updated second conda environment

Confirmed second conda environment also need pip version to be initially fixed at 9.0.3

* Change package name from mg-scripts to spp

* Spelling correction

* Bugfix

Resolved moving trimmed files bug.

* Adjust path for testing purposes

* Replaced sample csv metadata

Replaced sample csv metadata with test metadata from metapool.
Sequence_processing_pipeline now needs compliant metadata.

* Change list parameter to a string

* Add line to exclude configuration.json

* Adjusting plugin() call

* Refactored klp.py to support generic input paths

* Adjust expected result

* Added missing param

* Fix assertion for second test

* Report error message

* Added an empty run-dir to the test.

Added an empty run-dir to the test, to pass Pipeline()'s assertions.

* Fix syntax error

* Added creation of RTAComplete.txt file.

Pipeline() object examines any discovered directories named <run_id> for an RTAComplete.txt file.

* Added skip-execution parameter

Skip-execution parameter allows the sequence_processing_pipeline method to create all objects and test their assertions, etc. without actually running the commands.

* Changed bool to boolean

the string 'bool' should instead be 'boolean'.

* Added fake files to accomodate ConvertJob & QCJob

* Change open status

* Added sample multqc-config file

* Fix function call

* Added directories to support GenPrepFileJob

* fix

* Changed directory to match GenPrepFileJob's expectations.

* Adjusting assertEquals() test

Adjusting assertEquals() test so that it doesn't compare two ArtifactInfos() by memory-location/

* Adjusted expected AInfo results

Adjusted expected AInfo results to account for the new 'final_results' sub-directory.
Added tarball of prep-files back as a product. Prep-files are still moved to uploads.

* Add logging for Ainfo

* Adjusted expected output

* Changed added plugin parameters to env variables

* Updates

* Update .github/workflows/qiita-plugin-ci.yml

* Apply suggestions from code review

* Removing PipelineError catch-all

* Adjust message to be more specific

* Removed reappearing hardcode

Co-authored-by: Antonio Gonzalez <antgonza@gmail.com>